### PR TITLE
Remove deprecated lint for ~[T]s

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![feature(default_type_params)]
 #![warn(unnecessary_qualification, non_uppercase_statics,
         variant_size_difference, managed_heap_memory, unnecessary_typecast,
-        missing_doc, unused_result, deprecated_owned_vector)]
+        missing_doc, unused_result)]
 
 #[cfg(test)]
 extern crate test;


### PR DESCRIPTION
Since ~/box [T] was removed from the language, the lint for `deprecated_owned_vector` has
also been removed. This PR just removes the lint for it as it is now a syntax error and
having this lint produces a warning.
