### PR TITLE
Fixes syntax error in new version of rust.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ impl AnyMap {
     /// Set the value contained in the map for the type `T`.
     /// This will override any previous value stored.
     pub fn insert<T: 'static>(&mut self, value: T) {
-        self.data.insert(TypeId::of::<T>(), box value as Box<Any>:'static);
+        self.data.insert(TypeId::of::<T>(), box value as Box<Any>);
     }
 
     /// Remove the value for the type `T` if it existed.


### PR DESCRIPTION
Just removes a lifetime qualifier that caused a syntax error in rust-nightly.
All tests/benchmarks still work and pass.
