### PR TITLE
Fixes syntax error with latest nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ impl<'a> UncheckedAnyMutRefExt<'a> for &'a mut Any {
 ///
 /// Values containing non-static references are not permitted.
 pub struct AnyMap {
-    data: HashMap<TypeId, Box<Any>:'static, TypeIdHasher>,
+    data: HashMap<TypeId, Box<Any>, TypeIdHasher>,
 }
 
 impl AnyMap {


### PR DESCRIPTION
`data: HashMap<TypeId, Box<Any>:'static, TypeIdHasher>` now causes a syntax error at \'static.

This PR removes the \'static bound as it is now a syntax error and unnecessary as the `Any`
trait is only implemented by objects with a \'static lifetime, so non-\'static items could
never be stored in AnyMap.
