### PR TITLE
Fix int type inference in range calls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ impl Mutable for AnyMap {
 fn bench_insertion(b: &mut ::test::Bencher) {
     b.iter(|| {
         let mut data = AnyMap::new();
-        for _ in range(0, 100) {
+        for _ in range(0u, 100) {
             data.insert(42i);
         }
     })
@@ -174,7 +174,7 @@ fn bench_insertion(b: &mut ::test::Bencher) {
 fn bench_find_missing(b: &mut ::test::Bencher) {
     b.iter(|| {
         let data = AnyMap::new();
-        for _ in range(0, 100) {
+        for _ in range(0u, 100) {
             assert_eq!(data.find(), None::<&int>);
         }
     })
@@ -186,7 +186,7 @@ fn bench_find_present(b: &mut ::test::Bencher) {
         let mut data = AnyMap::new();
         data.insert(42i);
         // These inner loops are a feeble attempt to drown the other factors.
-        for _ in range(0, 100) {
+        for _ in range(0u, 100) {
             assert_eq!(data.find(), Some(&42i));
         }
     })


### PR DESCRIPTION
Integer suffixes are required to deduce the exact type. Fixes build problem with rust nightly.
