### PR TITLE
Add contains method for checking if a type is already in the map.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,11 @@ impl AnyMap {
     pub fn remove<T: 'static>(&mut self) {
         self.data.remove(&TypeId::of::<T>());
     }
+
+    /// Does a value of type `T` exist?
+    pub fn contains<T: 'static>(&self) -> bool {
+        self.data.contains_key(&TypeId::of::<T>())
+    }
 }
 
 impl Collection for AnyMap {


### PR DESCRIPTION
This is just a generally useful method to have around.
