### PR TITLE
make TypeId derive Copy, like the real one

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ mod with_clone {
     }
 
     /// TypeId, but implementing Clone.
-    #[deriving(PartialEq, Eq, Show)]
+    #[deriving(PartialEq, Eq, Copy, Show)]
     pub struct TypeId(::std::intrinsics::TypeId);
 
     impl TypeId {


### PR DESCRIPTION
This fixes it in the latest Rust nightly, which incorporated the change [discussed here](https://github.com/rust-lang/rust/pull/17864).
