### PR TITLE
adjust trait bound for with_clone::Any

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! This crate provides the `AnyMap` type, a safe and convenient store for one value of each type.
 
-#![feature(core, std_misc, convert)]
+#![feature(core, std_misc)]
 #![cfg_attr(test, feature(test))]
 #![warn(missing_docs, unused_results)]
 
@@ -346,9 +346,13 @@ mod tests {
                 *v = new_v;
             }
         }
-        assert_eq!(map.get().unwrap(), &B(200));
-        assert_eq!(map.len(), 6);
 
+        {
+            let b: &B = map.get().unwrap();
+            assert_eq!(b, &B(200));
+        }
+
+        assert_eq!(map.len(), 6);
 
         // Existing key (remove)
         match map.entry::<C>() {

--- a/src/with_clone.rs
+++ b/src/with_clone.rs
@@ -16,7 +16,7 @@ impl<T: 'static + Clone> CloneToAny for T {
 /// Pretty much just `std::any::Any + Clone`.
 pub trait Any: ::std::any::Any + CloneToAny { }
 
-impl<T: 'static + Clone> Any for T { }
+impl<T: 'static + Clone + Any> Any for T { }
 
 impl Clone for Box<Any> {
     fn clone(&self) -> Box<Any> {


### PR DESCRIPTION
I believe the [new] std::marker::[Reflect] trait made it necessary to
specify a Reflect bound, but it's advised to use an Any bound instead.

Adding this bound makes it compile. I ran the tests and got an error
saying it couldn't determine the type of one of the expressions so I
introduced a scope to bind the result of the expression and annotate its
type.

I also removed the `convert` feature that was no longer needed.

[new]: https://github.com/rust-lang/rust/pull/23712
[Reflect]: http://doc.rust-lang.org/std/marker/trait.Reflect.html