### PR TITLE
Add contains_key method allowing the TypeId to be passed in as a func…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,12 @@ impl<A: ?Sized + UncheckedAnyExt> Map<A> {
         self.raw.contains_key(&TypeId::of::<T>())
     }
 
+    /// Returns true if the collection contains a value of type `T`.
+    #[inline]
+    pub fn contains_key(&self, id: &TypeId) -> bool {
+        self.raw.contains_key(id)
+    }
+
     /// Gets the entry for the given type in the collection for in-place manipulation
     #[inline]
     pub fn entry<T: IntoBox<A>>(&mut self) -> Entry<A, T> {


### PR DESCRIPTION
…tion param.

Hey! Awesome library, picked it up for a first pass at a really simple rust-based ECS framework. Ran into this slight hiccup with some of my code, and hoped that this method could be added.

Use case:

```rust
let types = vec!(TypeId::of::<Foo>());
let map = AnyMap::new();
map.insert::<Foo>(Foo(1));
assert!(type().into_iter().all(| id | map.contains_key(id)))
```

I tried using the RawMap functionality as this method's exposed there, but realised that I'd have to then reimplement most of AnyMap over the top of it to get the safe accessors, so figured this would be the quicker implementation.

Critique welcome, still learning the ropes with Rust.