### PR TITLE
removed unsafe code in favor of explicit assert

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -10,7 +10,6 @@ use std::hash::{Hasher, BuildHasherDefault};
 #[cfg(test)]
 use std::mem;
 use std::ops::{Index, IndexMut};
-use std::ptr;
 
 use any::{Any, UncheckedAnyExt};
 
@@ -23,10 +22,11 @@ impl Hasher for TypeIdHasher {
     #[inline]
     fn write(&mut self, bytes: &[u8]) {
         // This expects to receive one and exactly one 64-bit value
-        debug_assert!(bytes.len() == 8);
-        unsafe {
-            ptr::copy_nonoverlapping(&bytes[0] as *const u8 as *const u64, &mut self.value, 1)
-        }
+        assert!(bytes.len() == 8);
+        self.value = u64::from(bytes[0])       | u64::from(bytes[1]) << 8  |
+                     u64::from(bytes[2]) << 16 | u64::from(bytes[3]) << 24 |
+                     u64::from(bytes[4]) << 32 | u64::from(bytes[5]) << 40 |
+                     u64::from(bytes[6]) << 48 | u64::from(bytes[7]) << 56;
     }
 
     #[inline]


### PR DESCRIPTION
converting a `*u8` to a `*u64` is/could be unsafe, because of different alignment.

```
 casting from `*const u8` to a more-strictly-aligned pointer (`*const u64`)                                                                                                       
   --> src/raw.rs:28:38                                                                                                                                                                  
      |
   28 |             ptr::copy_nonoverlapping(&bytes[0] as *const u8 as *const u64, &mut self.value, 1)                                                                                     
      |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                          
      |                                                                                                                                                                                    
   = note: #[deny(clippy::cast_ptr_alignment)] on by default                                                                                                                            
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_ptr_alignment    
```

This PR will have no runtime effect, because `assert!` influences the code generated by rust/llvm, so they are equal, but less unsafe :)

https://rust.godbolt.org/z/FXkwB2