### PR TITLE
Convert to `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/chris-morgan/anymap"
 readme = "README.md"
 keywords = ["container", "data-structure", "map"]
 license = "MIT/Apache-2.0"
+
+[dependencies]
+hashbrown = "0.6.3"

--- a/src/any.rs
+++ b/src/any.rs
@@ -3,8 +3,9 @@
 //! This stuff is all based on `std::any`, but goes a little further, with `CloneAny` being a
 //! cloneable `Any` and with the `Send` and `Sync` bounds possible on both `Any` and `CloneAny`.
 
-use std::fmt;
-use std::any::Any as StdAny;
+use alloc::boxed::Box;
+use core::fmt;
+use core::any::Any as StdAny;
 
 #[doc(hidden)]
 pub trait CloneToAny {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,13 @@
 //! This crate provides the `AnyMap` type, a safe and convenient store for one value of each type.
-
+#![no_std]
 #![warn(missing_docs, unused_results)]
 
-use std::any::TypeId;
-use std::marker::PhantomData;
+extern crate alloc;
+extern crate hashbrown;
+
+use alloc::{boxed::Box, vec::Vec};
+use core::any::TypeId;
+use core::marker::PhantomData;
 
 use raw::RawMap;
 use any::{UncheckedAnyExt, IntoBox, Any};
@@ -427,7 +431,7 @@ mod tests {
         fn assert_send<T: Send>() { }
         fn assert_sync<T: Sync>() { }
         fn assert_clone<T: Clone>() { }
-        fn assert_debug<T: ::std::fmt::Debug>() { }
+        fn assert_debug<T: ::core::fmt::Debug>() { }
         assert_send::<Map<Any + Send>>();
         assert_send::<Map<Any + Send + Sync>>();
         assert_sync::<Map<Any + Sync>>();

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -2,14 +2,14 @@
 //!
 //! All relevant details are in the `RawMap` struct.
 
-use std::any::TypeId;
-use std::borrow::Borrow;
-use std::collections::hash_map::{self, HashMap};
-use std::hash::Hash;
-use std::hash::{Hasher, BuildHasherDefault};
+use core::any::TypeId;
+use alloc::{borrow::Borrow, boxed::Box, vec::Vec};
+use hashbrown::hash_map::{self, HashMap};
+use core::hash::Hash;
+use core::hash::{Hasher, BuildHasherDefault};
 #[cfg(test)]
-use std::mem;
-use std::ops::{Index, IndexMut};
+use core::mem;
+use core::ops::{Index, IndexMut};
 
 use any::{Any, UncheckedAnyExt};
 
@@ -258,12 +258,12 @@ impl<A: ?Sized + UncheckedAnyExt> IntoIterator for RawMap<A> {
 
 /// A view into a single occupied location in a `RawMap`.
 pub struct OccupiedEntry<'a, A: ?Sized + UncheckedAnyExt> {
-    inner: hash_map::OccupiedEntry<'a, TypeId, Box<A>>,
+    inner: hash_map::OccupiedEntry<'a, TypeId, Box<A>, BuildHasherDefault<TypeIdHasher>>,
 }
 
 /// A view into a single empty location in a `RawMap`.
 pub struct VacantEntry<'a, A: ?Sized + UncheckedAnyExt> {
-    inner: hash_map::VacantEntry<'a, TypeId, Box<A>>,
+    inner: hash_map::VacantEntry<'a, TypeId, Box<A>, BuildHasherDefault<TypeIdHasher>>,
 }
 
 /// A view into a single location in a `RawMap`, which may be vacant or occupied.


### PR DESCRIPTION
Make the necessary changes to allow building in a `no_std` environment.

This adds a dependency on `hashbrown`. This is the underlying implementation of `std::collections::HashMap`, so it was essentially a dependency before. Without `std` I just had to make it explicit.

