### PR TITLE
Rust2018 + easy send+sync AnyMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "anymap"
 version = "0.12.1"
+edition = "2018"
 authors = ["Chris Morgan <me@chrismorgan.info>"]
 description = "A safe and convenient store for one value of each type"
 documentation = "https://docs.rs/anymap"

--- a/src/any.rs
+++ b/src/any.rs
@@ -9,36 +9,36 @@ use std::any::Any as StdAny;
 #[doc(hidden)]
 pub trait CloneToAny {
     /// Clone `self` into a new `Box<CloneAny>` object.
-    fn clone_to_any(&self) -> Box<CloneAny>;
+    fn clone_to_any(&self) -> Box<dyn CloneAny>;
 
     /// Clone `self` into a new `Box<CloneAny + Send>` object.
-    fn clone_to_any_send(&self) -> Box<CloneAny + Send> where Self: Send;
+    fn clone_to_any_send(&self) -> Box<dyn CloneAny + Send> where Self: Send;
 
     /// Clone `self` into a new `Box<CloneAny + Sync>` object.
-    fn clone_to_any_sync(&self) -> Box<CloneAny + Sync> where Self: Sync;
+    fn clone_to_any_sync(&self) -> Box<dyn CloneAny + Sync> where Self: Sync;
 
     /// Clone `self` into a new `Box<CloneAny + Send + Sync>` object.
-    fn clone_to_any_send_sync(&self) -> Box<CloneAny + Send + Sync> where Self: Send + Sync;
+    fn clone_to_any_send_sync(&self) -> Box<dyn CloneAny + Send + Sync> where Self: Send + Sync;
 }
 
 impl<T: Any + Clone> CloneToAny for T {
     #[inline]
-    fn clone_to_any(&self) -> Box<CloneAny> {
+    fn clone_to_any(&self) -> Box<dyn CloneAny> {
         Box::new(self.clone())
     }
 
     #[inline]
-    fn clone_to_any_send(&self) -> Box<CloneAny + Send> where Self: Send {
+    fn clone_to_any_send(&self) -> Box<dyn CloneAny + Send> where Self: Send {
         Box::new(self.clone())
     }
 
     #[inline]
-    fn clone_to_any_sync(&self) -> Box<CloneAny + Sync> where Self: Sync {
+    fn clone_to_any_sync(&self) -> Box<dyn CloneAny + Sync> where Self: Sync {
         Box::new(self.clone())
     }
 
     #[inline]
-    fn clone_to_any_send_sync(&self) -> Box<CloneAny + Send + Sync> where Self: Send + Sync {
+    fn clone_to_any_send_sync(&self) -> Box<dyn CloneAny + Send + Sync> where Self: Send + Sync {
         Box::new(self.clone())
     }
 }
@@ -108,33 +108,33 @@ pub trait IntoBox<A: ?Sized + UncheckedAnyExt>: Any {
 
 macro_rules! implement {
     ($base:ident, $(+ $bounds:ident)*) => {
-        impl fmt::Debug for $base $(+ $bounds)* {
+        impl fmt::Debug for dyn $base $(+ $bounds)* {
             #[inline]
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.pad(stringify!($base $(+ $bounds)*))
             }
         }
 
-        impl UncheckedAnyExt for $base $(+ $bounds)* {
+        impl UncheckedAnyExt for dyn $base $(+ $bounds)* {
             #[inline]
-            unsafe fn downcast_ref_unchecked<T: 'static>(&self) -> &T {
+            unsafe fn downcast_ref_unchecked<T>(&self) -> &T {
                 &*(self as *const Self as *const T)
             }
 
             #[inline]
-            unsafe fn downcast_mut_unchecked<T: 'static>(&mut self) -> &mut T {
+            unsafe fn downcast_mut_unchecked<T>(&mut self) -> &mut T {
                 &mut *(self as *mut Self as *mut T)
             }
 
             #[inline]
-            unsafe fn downcast_unchecked<T: 'static>(self: Box<Self>) -> Box<T> {
+            unsafe fn downcast_unchecked<T>(self: Box<Self>) -> Box<T> {
                 Box::from_raw(Box::into_raw(self) as *mut T)
             }
         }
 
-        impl<T: $base $(+ $bounds)*> IntoBox<$base $(+ $bounds)*> for T {
+        impl<T: $base $(+ $bounds)*> IntoBox<dyn $base $(+ $bounds)*> for T {
             #[inline]
-            fn into_box(self) -> Box<$base $(+ $bounds)*> {
+            fn into_box(self) -> Box<dyn $base $(+ $bounds)*> {
                 Box::new(self)
             }
         }
@@ -152,7 +152,7 @@ implement!(CloneAny, + Sync);
 implement!(CloneAny, + Send + Sync);
 
 define!(CloneAny);
-impl_clone!(CloneAny, clone_to_any);
-impl_clone!((CloneAny + Send), clone_to_any_send);
-impl_clone!((CloneAny + Sync), clone_to_any_sync);
-impl_clone!((CloneAny + Send + Sync), clone_to_any_send_sync);
+impl_clone!(dyn CloneAny, clone_to_any);
+impl_clone!((dyn    CloneAny + Send), clone_to_any_send);
+impl_clone!((dyn    CloneAny + Sync), clone_to_any_sync);
+impl_clone!((dyn    CloneAny + Send + Sync), clone_to_any_send_sync);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 //! This crate provides the `AnyMap` type, a safe and convenient store for one value of each type.
 
 #![warn(missing_docs, unused_results)]
-
+#![deny(warnings)]
 use std::any::TypeId;
 use std::marker::PhantomData;
 
-use raw::RawMap;
-use any::{UncheckedAnyExt, IntoBox, Any};
+use crate::raw::RawMap;
+use crate::any::{UncheckedAnyExt, IntoBox, Any};
 
 macro_rules! impl_common_methods {
     (
@@ -120,7 +120,7 @@ pub mod raw;
 ///
 /// Values containing non-static references are not permitted.
 #[derive(Debug)]
-pub struct Map<A: ?Sized + UncheckedAnyExt = Any> {
+pub struct Map<A: ?Sized + UncheckedAnyExt = dyn Any> {
     raw: RawMap<A>,
 }
 
@@ -139,7 +139,7 @@ impl<A: ?Sized + UncheckedAnyExt> Clone for Map<A> where Box<A>: Clone {
 /// Why is this a separate type alias rather than a default value for `Map<A>`? `Map::new()`
 /// doesn’t seem to be happy to infer that it should go with the default value.
 /// It’s a bit sad, really. Ah well, I guess this approach will do.
-pub type AnyMap = Map<Any>;
+pub type AnyMap = Map<dyn Any>;
 
 impl_common_methods! {
     field: Map.raw;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! This crate provides the `AnyMap` type, a safe and convenient store for one value of each type.
 
 #![warn(missing_docs, unused_results)]
-#![deny(warnings)]
+//#![deny(warnings)]
 use std::any::TypeId;
 use std::marker::PhantomData;
 
@@ -140,6 +140,9 @@ impl<A: ?Sized + UncheckedAnyExt> Clone for Map<A> where Box<A>: Clone {
 /// doesn’t seem to be happy to infer that it should go with the default value.
 /// It’s a bit sad, really. Ah well, I guess this approach will do.
 pub type AnyMap = Map<dyn Any>;
+
+/// Sync version
+pub type SyncAnyMap = Map<dyn Any + Send + Sync>;
 
 impl_common_methods! {
     field: Map.raw;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,8 +314,8 @@ impl<'a, A: ?Sized + UncheckedAnyExt, V: IntoBox<A>> VacantEntry<'a, A, V> {
 
 #[cfg(test)]
 mod tests {
-    use {Map, AnyMap, Entry};
-    use any::{Any, CloneAny};
+    use crate::{Map, AnyMap, Entry};
+    use crate::any::{Any, CloneAny};
 
     #[derive(Clone, Debug, PartialEq)] struct A(i32);
     #[derive(Clone, Debug, PartialEq)] struct B(i32);
@@ -397,7 +397,7 @@ mod tests {
     }
 
     test_entry!(test_entry_any, AnyMap);
-    test_entry!(test_entry_cloneany, Map<CloneAny>);
+    test_entry!(test_entry_cloneany, Map<dyn CloneAny>);
 
     #[test]
     fn test_default() {
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn test_clone() {
-        let mut map: Map<CloneAny> = Map::new();
+        let mut map: Map<dyn CloneAny> = Map::new();
         let _ = map.insert(A(1));
         let _ = map.insert(B(2));
         let _ = map.insert(D(3));
@@ -431,25 +431,25 @@ mod tests {
         fn assert_sync<T: Sync>() { }
         fn assert_clone<T: Clone>() { }
         fn assert_debug<T: ::std::fmt::Debug>() { }
-        assert_send::<Map<Any + Send>>();
-        assert_send::<Map<Any + Send + Sync>>();
-        assert_sync::<Map<Any + Sync>>();
-        assert_sync::<Map<Any + Send + Sync>>();
-        assert_debug::<Map<Any>>();
-        assert_debug::<Map<Any + Send>>();
-        assert_debug::<Map<Any + Sync>>();
-        assert_debug::<Map<Any + Send + Sync>>();
-        assert_send::<Map<CloneAny + Send>>();
-        assert_send::<Map<CloneAny + Send + Sync>>();
-        assert_sync::<Map<CloneAny + Sync>>();
-        assert_sync::<Map<CloneAny + Send + Sync>>();
-        assert_clone::<Map<CloneAny + Send>>();
-        assert_clone::<Map<CloneAny + Send + Sync>>();
-        assert_clone::<Map<CloneAny + Sync>>();
-        assert_clone::<Map<CloneAny + Send + Sync>>();
-        assert_debug::<Map<CloneAny>>();
-        assert_debug::<Map<CloneAny + Send>>();
-        assert_debug::<Map<CloneAny + Sync>>();
-        assert_debug::<Map<CloneAny + Send + Sync>>();
+        assert_send::<Map<dyn Any + Send>>();
+        assert_send::<Map<dyn Any + Send + Sync>>();
+        assert_sync::<Map<dyn Any + Sync>>();
+        assert_sync::<Map<dyn Any + Send + Sync>>();
+        assert_debug::<Map<dyn Any>>();
+        assert_debug::<Map<dyn Any + Send>>();
+        assert_debug::<Map<dyn Any + Sync>>();
+        assert_debug::<Map<dyn Any + Send + Sync>>();
+        assert_send::<Map<dyn CloneAny + Send>>();
+        assert_send::<Map<dyn CloneAny + Send + Sync>>();
+        assert_sync::<Map<dyn CloneAny + Sync>>();
+        assert_sync::<Map<dyn CloneAny + Send + Sync>>();
+        assert_clone::<Map<dyn CloneAny + Send>>();
+        assert_clone::<Map<dyn CloneAny + Send + Sync>>();
+        assert_clone::<Map<dyn CloneAny + Sync>>();
+        assert_clone::<Map<dyn CloneAny + Send + Sync>>();
+        assert_debug::<Map<dyn CloneAny>>();
+        assert_debug::<Map<dyn CloneAny + Send>>();
+        assert_debug::<Map<dyn CloneAny + Sync>>();
+        assert_debug::<Map<dyn CloneAny + Send + Sync>>();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ impl<A: ?Sized + UncheckedAnyExt> Clone for Map<A> where Box<A>: Clone {
 pub type AnyMap = Map<dyn Any>;
 
 /// Sync version
-pub type SyncAnyMap = Map<dyn Any + Send + Sync>;
+pub type SendSyncAnyMap = Map<dyn Any + Send + Sync>;
 
 impl_common_methods! {
     field: Map.raw;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -11,7 +11,7 @@ use std::hash::{Hasher, BuildHasherDefault};
 use std::mem;
 use std::ops::{Index, IndexMut};
 
-use any::{Any, UncheckedAnyExt};
+use crate::any::{Any, UncheckedAnyExt};
 
 #[derive(Default)]
 struct TypeIdHasher {
@@ -56,7 +56,7 @@ fn type_id_hasher() {
 /// contents of an `Map`. However, because you will then be dealing with `Any` trait objects, it
 /// doesn’t tend to be so very useful. Still, if you need it, it’s here.
 #[derive(Debug)]
-pub struct RawMap<A: ?Sized + UncheckedAnyExt = Any> {
+pub struct RawMap<A: ?Sized + UncheckedAnyExt = dyn Any> {
     inner: HashMap<TypeId, Box<A>, BuildHasherDefault<TypeIdHasher>>,
 }
 


### PR DESCRIPTION
This mostly brings the library in line with Rust 2018 by introducing the needed `dyns`. 

It also puts a `SendSyncAnyMap` in the root as rust was throwing a fit about performing the identical line of code outside the library. If I use the type as is, inside the library it returns:

```
the trait `anymap::any::UncheckedAnyExt` is not implemented for `(dyn std::any::Any + std::marker::Send + std::marker::Sync + 'static)`
```

I think it's because you redefine `Any` inside your library, but am not sure.