### PR TITLE
`Fetcher` api for multiple mutable value access.

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,0 +1,43 @@
+use core::any::{Any, TypeId};
+use std::collections::HashSet;
+
+use crate::{
+    any::{Downcast, IntoBox},
+    Map,
+};
+
+/// A container for a [`Map`] that allows for multiple mutable access of unique values.
+pub struct Fetcher<'a, A: ?Sized + Downcast = dyn Any> {
+    mask: HashSet<TypeId>,
+    map: &'a mut Map<A>,
+}
+
+impl<'a, A: ?Sized + Downcast> Fetcher<'a, A> {
+    /// Returns a new Fetcher that retrieves values from `map`.
+    pub fn new(map: &'a mut Map<A>) -> Self {
+        Self {
+            mask: Default::default(),
+            map,
+        }
+    }
+
+    /// Fetches and returns a mutable reference to the value
+    /// stored in the collection for the type `T`, if it exists.
+    ///
+    /// This method may be used multiple times while the reference is still alive.
+    /// However, another request to the same type will result in `None`.
+    pub fn fetch<T: IntoBox<A>>(&mut self) -> Option<&'a mut T> {
+        // first insert id into mask, and check if it was there already
+        if !self.mask.insert(TypeId::of::<T>()) {
+            return None;
+        }
+
+        // then retrieve the value
+        let value = self.map.get_mut::<T>()?;
+
+        // SAFETY: Transmuting here only changes the lifetime of the value.
+        // While this would normally be unsafe, the mask ensures that the user
+        // is never able to mutably access the same data twice.
+        Some(unsafe { std::mem::transmute(value) })
+    }
+}


### PR DESCRIPTION
*This is intended as an initial discussion PR and not a completed/documented feature. While the feature **will** work as submitted. I believe more discussion is required, and an obvious clean up would be due.*

I am often burdened by the lack of aliasing hints for the rust compiler and end up wanting multiple mutable access to data that ***should be*** completely safe. Since there is no way to tell a method what it aliases, it is automatically assumed that it aliases over the entire struct that it is attached to.

Because of the above, it is impossible to get multiple mutable values out of a map. This PR is an attempt to create a discussion around a potential solution to that problem.

Please let me know what you think.